### PR TITLE
Adapt to new versions of numpy (as float indexing no more permitted)

### DIFF
--- a/Elements.py
+++ b/Elements.py
@@ -426,8 +426,12 @@ class WavePropagationElement(Element):
                 
             #Wall-Thickness
             if type(self.WallThickness) is not str:
-                h1 = (self.WallThickness[s2] - self.WallThickness[s1])/self.Length
-                h2 = self.WallThickness[s1]
+                len_wall_thickness = len(self.WallThickness)-1
+                idx_st = int(len_wall_thickness * s1)
+                idx_end = int(len_wall_thickness * s2)
+
+                h1 = (self.WallThickness[idx_end] - self.WallThickness[idx_st])/self.Length
+                h2 = self.WallThickness[idx_st]
                 h_z = h2+(h1*z)
                 self.WallThickness = h_z
             else:
@@ -435,10 +439,14 @@ class WavePropagationElement(Element):
                 evaluator.Evaluate(self.WallThickness)
                 
             #Young's Modulus
-            E1 = (self.YoungModulus[s2] - self.YoungModulus[s1])/self.Length
-            E2 = self.YoungModulus[s1]
+            len_young_modulus = len(self.YoungModulus)-1
+            idx_st = int(len_young_modulus * s1) if type(self.YoungModulus) != dict else s1
+            idx_end = int(len_young_modulus * s2) if type(self.YoungModulus) != dict else s2
+
+            E1 = (self.YoungModulus[idx_end] - self.YoungModulus[idx_st])/self.Length
+            E2 = self.YoungModulus[idx_st]
             E_z = E2+(E1*z)
-            self.YoungModulus = E_z 
+            self.YoungModulus = E_z
             
             #Resistance
             if self.Resistance == None:

--- a/Solver.py
+++ b/Solver.py
@@ -225,7 +225,7 @@ class SolverFirstTrapezoid(Solver):
                 if not nonLinear :
                     break
 
-                if self.pi == None:
+                if self.pi is None:
                     self.pi = zeros((NumberOfGlobalDofs,1))
                     self.pi[:,:] = self.pt[:,:]
                 pI = CoeffRelax * self.p + self.pi * (1.0-CoeffRelax)


### PR DESCRIPTION
Should fix IndexErrors like:

> IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

This was due to Numpy which [as of version 1.12 doesn't accept floats as indexes anymore](
https://github.com/numpy/numpy/blob/master/doc/release/1.12.0-notes.rst#deprecationwarning-to-error). 